### PR TITLE
Switch figures PDF source to the CDN bucket

### DIFF
--- a/src/router/models.py
+++ b/src/router/models.py
@@ -12,14 +12,12 @@ class eLifeFile():
     def __init__ (self):
         self.cdn_base_url = 'http://cdn.elifesciences.org/'
         self.s3_base_url = 'http://s3.amazonaws.com/'
-        self.figure_pdf_folder = 'figure-pdf/'
         self.cdn_articles_folder = 'elife-articles/'
         self.glencoe_api_base_url = 'http://movie-usa.glencoesoftware.com/'
         self.glencoe_metadata_endpoint = 'metadata/'
         
         # Bucket names
         self.cdn_bucket_name = 'elife-cdn'
-        self.figure_pdf_bucket_name = 'elife-figure-pdfs'
     
     def get_doi_id(self):
         """
@@ -93,7 +91,9 @@ class PdfFile(eLifeFile):
         It is used in both the CDN URL and the S3 bucket URL
         """
         if self.type == "figures":
-            return self.figure_pdf_folder
+            return (self.cdn_articles_folder
+                            + str(self.get_doi_id()).zfill(5)
+                            + '/' + 'figures-pdf/')
         elif self.type == "article":
             return (self.cdn_articles_folder
                             + str(self.get_doi_id()).zfill(5)
@@ -126,7 +126,7 @@ class PdfFile(eLifeFile):
 
         # Specify in which bucket the file is stored
         if self.type == "figures":
-            bucket_url = self.s3_base_url + self.figure_pdf_bucket_name
+            bucket_url = self.s3_base_url + self.cdn_bucket_name
         elif self.type == "article":
             bucket_url = self.s3_base_url + self.cdn_bucket_name
         

--- a/src/router/tests.py
+++ b/src/router/tests.py
@@ -95,22 +95,23 @@ class eLifeTestCase(TestCase):
         "test parsing S3 object metadata XML"
         
         # Result of
-        # GET http://s3.amazonaws.com/elife-figure-pdfs?prefix=figure-pdf/elife00829-figures.pdf
-        prefix = 'figure-pdf/elife00829-figures.pdf'
+        # GET http://s3.amazonaws.com/elife-cdn?prefix=elife-articles/00829/figures-pdf/elife00829-figures.pdf
+        prefix = 'elife-articles/00829/figures-pdf/elife00829-figures.pdf'
         xml_string = ('<?xml version="1.0" encoding="UTF-8"?>'
-                      + '<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
-                      + '<Name>elife-figure-pdfs</Name>'
-                      + '<Prefix>figure-pdf/elife00829-figures.pdf</Prefix>'
-                      + '<Marker></Marker>'
-                      + '<MaxKeys>1000</MaxKeys>'
-                      + '<IsTruncated>false</IsTruncated>'
-                      + '<Contents>'
-                      + '<Key>figure-pdf/elife00829-figures.pdf</Key>'
-                      + '<LastModified>2014-11-25T16:56:05.000Z</LastModified>'
-                      + '<ETag>&quot;82200c757af15dd8c0c85a39f74e4661&quot;</ETag>'
-                      + '<Size>768145</Size>'
-                      + '<StorageClass>STANDARD</StorageClass>'
-                      + '</Contents></ListBucketResult>')
+                        + '<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+                        + '<Name>elife-cdn</Name>'
+                        + '<Prefix>elife-articles/00829/figures-pdf/elife00829-figures.pdf</Prefix>'
+                        + '<Marker></Marker>'
+                        + '<MaxKeys>1000</MaxKeys>'
+                        + '<IsTruncated>false</IsTruncated>'
+                        + '<Contents>'
+                        + '<Key>elife-articles/00829/figures-pdf/elife00829-figures.pdf</Key>'
+                        + '<LastModified>2015-01-29T23:50:00.000Z</LastModified>'
+                        + '<ETag>&quot;82200c757af15dd8c0c85a39f74e4661&quot;</ETag>'
+                        + '<Size>768145</Size>'
+                        + '<StorageClass>STANDARD</StorageClass>'
+                        + '</Contents>'
+                        + '</ListBucketResult>')
         size = 768145
         
         s3_data = self.elf.parse_s3_xml(xml_string)


### PR DESCRIPTION
Figures PDF URL now comes from the CDN bucket. The test based on S3 data is updated too and the old figures-pdf bucket is removed completely.