### PR TITLE
removes pyyaml from requirements, bumps Django 1.9 to 1.9.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,10 @@
 coverage==4.0.3
-Django==1.9
+Django==1.9.13
 django-annoying==0.8.5
 django-markdown2==0.2.1
 django-rest-swagger==0.3.4
 djangorestframework==3.3.2
 pylint==1.5.4
 pylint-django==0.7.1
-PyYAML==3.11
 requests==2.20.0
 unittest-xml-reporting==2.0.0


### PR DESCRIPTION
turns out there is no mention of yaml in elife-api at all. Django depends on it, so it does get installed, just not by us.