### PR TITLE
removes all usage of rest_framework from router.views.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.sqlite*
 *.log*
 src/collected-static/
+collected-static/
 venv/
 .coverage
 xml/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ coverage==4.0.3
 Django==1.11.20
 django-annoying==0.10.4
 django-markdown2==0.2.1
-djangorestframework==3.9.4
 pylint==1.5.4
 pylint-django==0.7.1
 requests==2.20.0

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -7,7 +7,6 @@ dev settings can be found in /path/to/api/dev.cfg
 
 import os
 from os.path import join
-from datetime import datetime
 import ConfigParser as configparser
 
 SRC_DIR = os.path.dirname(os.path.dirname(__file__)) # ll: /path/to/app/src/

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -47,8 +47,6 @@ INSTALLED_APPS = (
     'django_markdown2',
 
     'router',
-    
-    'rest_framework',
 )
 
 MIDDLEWARE_CLASSES = (

--- a/src/proxy/urls.py
+++ b/src/proxy/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.conf.urls import url
 from proxy import views
 
 urlpatterns = [

--- a/src/proxy/views.py
+++ b/src/proxy/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render, Http404
+from django.shortcuts import Http404
 
 def proxy(request):
     raise Http404("Not found! Proxying is handled by the webserver and *not* Django. You are seeing this error because the webserver is not configured to proxy requests as expected")

--- a/src/router/admin.py
+++ b/src/router/admin.py
@@ -1,3 +1,2 @@
-from django.contrib import admin
 
 # Register your models here.

--- a/src/router/models.py
+++ b/src/router/models.py
@@ -1,4 +1,3 @@
-from django.db import models
 import requests
 import json
 from xml.etree import ElementTree

--- a/src/router/tests.py
+++ b/src/router/tests.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from django.test.client import Client
-from models import *
+from models import eLifeFile, MediaFile
 
 class Routing(TestCase):
     def setUp(self):

--- a/src/router/urls.py
+++ b/src/router/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.conf.urls import url
 from router import views
 
 urlpatterns = [

--- a/src/router/views.py
+++ b/src/router/views.py
@@ -80,7 +80,7 @@ def pdf(request, doi, type = None):
                 pass
                
         except:
-            return HttpResponse(status=404) #status.HTTP_404_NOT_FOUND)
+            return HttpResponse(status=404)
 
     response_list = {}
     response_list['data'] = data

--- a/src/router/views.py
+++ b/src/router/views.py
@@ -1,13 +1,7 @@
-#from django.shortcuts import render
 from django.http import HttpResponse, HttpResponseRedirect
 from django.views.decorators.http import require_GET
-#from rest_framework import status
-#from rest_framework.response import Response
-#from rest_framework.decorators import api_view
-
 import requests
 import json
-#from models import *
 from models import PdfFile, MediaFile
 from annoying.decorators import render_to
 from os.path import join
@@ -18,14 +12,6 @@ def index(request):
     return {
         'readme': open(join(settings.PROJECT_DIR, 'README.md'), 'r').read()
     }
-
-
-#
-# utils
-#
-
-#def redirect(dest):
-#    return HttpResponseRedirect(dest)
 
 def check_url_exists(url):
     """
@@ -44,13 +30,10 @@ def check_url_exists(url):
 def json_response(data, status=200):
     return HttpResponse(json.dumps(data, indent=4), content_type="application/json", status=status)
 
-#@api_view(['GET'])
 @require_GET
 def hello_world(request):
-    #return Response({"message": "Hello, world!"})
     return json_response({"message": "Hello, world!"})
 
-#@api_view(['GET'])
 @require_GET
 def example_route(request, arg1, arg2):
     """
@@ -58,17 +41,8 @@ def example_route(request, arg1, arg2):
     arg1 -- A first argument
     arg2 -- A second argument
     """
-        
-    # Quick hack to get a Location redirect
-    #redirect_response = redirect('http://example.org/%s/%s/' % (arg1, arg2))
-    #headers = {}
-    #headers['Location'] = redirect_response.url
-    #return Response(
-    #    status=302, #status.HTTP_302_FOUND,
-    #    headers=headers)
     return HttpResponseRedirect('http://example.org/%s/%s/' % (arg1, arg2))
 
-#@api_view(['GET'])
 @require_GET
 def pdf(request, doi, type = None):
     """
@@ -116,10 +90,8 @@ def pdf(request, doi, type = None):
         response_list['notes'] = notes
     response_list['results'] = len(data)
 
-    #return Response(response_list)
     return json_response(response_list)
 
-#@api_view(['GET'])
 @require_GET
 def pdf_by_type(request, doi, type):
     """
@@ -128,7 +100,6 @@ def pdf_by_type(request, doi, type):
     """
     return pdf(request, doi, type)
     
-#@api_view(['GET'])
 @require_GET
 def media(request, doi, xlink = None, type = None, redirect = None):
     """
@@ -156,36 +127,22 @@ def media(request, doi, xlink = None, type = None, redirect = None):
 
     query_params = request.GET
     
-    #if (
-    #    (redirect is True or request.query_params.get('redirect') is not None)
-    #    and len(response_list['data']) == 1):
-
     if (
         (redirect is True or query_params.get('redirect') is not None)
         and len(response_list['data']) == 1):
         
-        # Only one URL returned and redirect
-        #headers = {}
-        #headers['Location'] = response_list['data'][0]['url']
-        #return Response(
-        #    status=302 #status.HTTP_302_FOUND,
-        #    headers=headers)
         return HttpResponseRedirect(response_list['data'][0]['url'])
     
-    #elif ((redirect is True or request.query_params.get('redirect') is not None)
-    #    and len(response_list['data']) < 1):
     elif ((redirect is True or query_params.get('redirect') is not None)
         and len(response_list['data']) < 1):
     
         # No URL return and redirect, error 404
-        return HttpResponse(status=404) #status.HTTP_404_NOT_FOUND)
+        return HttpResponse(status=404)
     
     else:
         # Default with no redirect, return all the data
-        #return Response(response_list)
         return json_response(response_list)
     
-#@api_view(['GET'])
 @require_GET
 def media_file(request, doi, filename):
     """
@@ -207,7 +164,6 @@ def media_file(request, doi, filename):
     
     return media(request, doi, xlink, type, redirect)
     
-#@api_view(['GET'])
 @require_GET
 def media_xlink_format(request, doi, xlink, type):
     """
@@ -218,4 +174,3 @@ def media_xlink_format(request, doi, xlink, type):
     """
     return media(request, doi, xlink, type)
 
-    

--- a/src/router/views.py
+++ b/src/router/views.py
@@ -1,10 +1,14 @@
-from django.shortcuts import render
-from django.http import HttpResponseRedirect
-from rest_framework import status
-from rest_framework.response import Response
-from rest_framework.decorators import api_view
+#from django.shortcuts import render
+from django.http import HttpResponse, HttpResponseRedirect
+from django.views.decorators.http import require_GET
+#from rest_framework import status
+#from rest_framework.response import Response
+#from rest_framework.decorators import api_view
+
 import requests
-from models import *
+import json
+#from models import *
+from models import PdfFile, MediaFile
 from annoying.decorators import render_to
 from os.path import join
 from django.conf import settings
@@ -20,8 +24,8 @@ def index(request):
 # utils
 #
 
-def redirect(dest):
-    return HttpResponseRedirect(dest)
+#def redirect(dest):
+#    return HttpResponseRedirect(dest)
 
 def check_url_exists(url):
     """
@@ -37,11 +41,17 @@ def check_url_exists(url):
         return None
     return None
 
-@api_view(['GET'])
-def hello_world(request):
-    return Response({"message": "Hello, world!"})
+def json_response(data, status=200):
+    return HttpResponse(json.dumps(data, indent=4), content_type="application/json", status=status)
 
-@api_view(['GET'])
+#@api_view(['GET'])
+@require_GET
+def hello_world(request):
+    #return Response({"message": "Hello, world!"})
+    return json_response({"message": "Hello, world!"})
+
+#@api_view(['GET'])
+@require_GET
 def example_route(request, arg1, arg2):
     """
     This text description for this API call
@@ -50,14 +60,16 @@ def example_route(request, arg1, arg2):
     """
         
     # Quick hack to get a Location redirect
-    redirect_response = redirect('http://example.org/%s/%s/' % (arg1, arg2))
-    headers = {}
-    headers['Location'] = redirect_response.url
-    return Response(
-        status=status.HTTP_302_FOUND,
-        headers=headers)
+    #redirect_response = redirect('http://example.org/%s/%s/' % (arg1, arg2))
+    #headers = {}
+    #headers['Location'] = redirect_response.url
+    #return Response(
+    #    status=302, #status.HTTP_302_FOUND,
+    #    headers=headers)
+    return HttpResponseRedirect('http://example.org/%s/%s/' % (arg1, arg2))
 
-@api_view(['GET'])
+#@api_view(['GET'])
+@require_GET
 def pdf(request, doi, type = None):
     """
     Get PDF file locations in JSON format.
@@ -94,7 +106,7 @@ def pdf(request, doi, type = None):
                 pass
                
         except:
-            return Response(status=status.HTTP_404_NOT_FOUND)
+            return HttpResponse(status=404) #status.HTTP_404_NOT_FOUND)
 
     response_list = {}
     response_list['data'] = data
@@ -104,9 +116,11 @@ def pdf(request, doi, type = None):
         response_list['notes'] = notes
     response_list['results'] = len(data)
 
-    return Response(response_list)
+    #return Response(response_list)
+    return json_response(response_list)
 
-@api_view(['GET'])
+#@api_view(['GET'])
+@require_GET
 def pdf_by_type(request, doi, type):
     """
     Get a PDF file URI
@@ -114,7 +128,8 @@ def pdf_by_type(request, doi, type):
     """
     return pdf(request, doi, type)
     
-@api_view(['GET'])
+#@api_view(['GET'])
+@require_GET
 def media(request, doi, xlink = None, type = None, redirect = None):
     """
     Get media file locations in JSON format.
@@ -139,24 +154,39 @@ def media(request, doi, xlink = None, type = None, redirect = None):
     response_list['data'] = data
     response_list['results'] = len(data)
 
+    query_params = request.GET
+    
+    #if (
+    #    (redirect is True or request.query_params.get('redirect') is not None)
+    #    and len(response_list['data']) == 1):
+
     if (
-        (redirect is True or request.query_params.get('redirect') is not None)
+        (redirect is True or query_params.get('redirect') is not None)
         and len(response_list['data']) == 1):
+        
         # Only one URL returned and redirect
-        headers = {}
-        headers['Location'] = response_list['data'][0]['url']
-        return Response(
-            status=status.HTTP_302_FOUND,
-            headers=headers)
-    elif ((redirect is True or request.query_params.get('redirect') is not None)
+        #headers = {}
+        #headers['Location'] = response_list['data'][0]['url']
+        #return Response(
+        #    status=302 #status.HTTP_302_FOUND,
+        #    headers=headers)
+        return HttpResponseRedirect(response_list['data'][0]['url'])
+    
+    #elif ((redirect is True or request.query_params.get('redirect') is not None)
+    #    and len(response_list['data']) < 1):
+    elif ((redirect is True or query_params.get('redirect') is not None)
         and len(response_list['data']) < 1):
+    
         # No URL return and redirect, error 404
-        return Response(status=status.HTTP_404_NOT_FOUND)
+        return HttpResponse(status=404) #status.HTTP_404_NOT_FOUND)
+    
     else:
         # Default with no redirect, return all the data
-        return Response(response_list)
+        #return Response(response_list)
+        return json_response(response_list)
     
-@api_view(['GET'])
+#@api_view(['GET'])
+@require_GET
 def media_file(request, doi, filename):
     """
     Get a specific media file
@@ -177,7 +207,8 @@ def media_file(request, doi, filename):
     
     return media(request, doi, xlink, type, redirect)
     
-@api_view(['GET'])
+#@api_view(['GET'])
+@require_GET
 def media_xlink_format(request, doi, xlink, type):
     """
     Get a specific media file by specifying the xlink and type


### PR DESCRIPTION
cc @giorgiosironi 

CI is a bit of a mess on elife-api right now. I know it's 'legacy', but the tests are failing after the security fix bumping `djangorestframework` and that library is just so much more trouble than it's worth these days.